### PR TITLE
[REVIEW] Test the latest stable ccache version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gpuci-ccache" %}
-{% set version = "3.7.12dev0" %}
+{% set version = "4.2.0dev0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/ccache/ccache.git
-  git_rev: 231fef47e48e27995c0c3ebc8db0ebd3de96b8fc
+  git_rev: 12ecd73fcd8aa7024d5851c1738223b8aff0c6e9
   patches: patch_test_suite.patch  # [osx]
 
 build:


### PR DESCRIPTION
CCache devs suggested using the latest version with our setup. This commit points to their latest stable commit, v4.2